### PR TITLE
Fix pytest fixture scoping for high memory usage.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-20.04, macOS-latest, windows-2019]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,9 @@ jobs:
         unzip mask-test-pack.zip
     - name: Test with pytest
       run: |
-        coverage run -m pytest
+        pytest
+        #temporarily disabling coverage for memory usage
+        #coverage run -m pytest
     - name: Report coverage
       run: |
         coverage report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,9 @@ jobs:
         unzip mask-test-pack.zip
     - name: Test with pytest
       run: |
-        pytest
+        #pytest -v
         #temporarily disabling coverage for memory usage
-        #coverage run -m pytest
+        coverage run -m pytest -v
     - name: Report coverage
       run: |
         coverage report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-20-04, macOS-latest, windows-latest]
+        os: [ubuntu-20.04, macOS-latest, windows-2019]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-20-04, macOS-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pyfai
 scikit-image
 scipy
 pillow
-xarray<=2022.12
+xarray
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pyfai
 scikit-image
 scipy
 pillow
-xarray
+xarray<=2022.12
 tqdm

--- a/tests/test_PFIntegrators.py
+++ b/tests/test_PFIntegrators.py
@@ -22,21 +22,21 @@ def sst_data():
         loader = SST1RSoXSLoader(corr_mode='none')
         return loader.loadFileSeries('Example/SST1/21792/',['energy','polarization'])
     
-@pytest.fixture(autouse=True,scope='module')
+@pytest.fixture()#autouse=True,scope='module')
 def pfgenint(sst_data):
     integrator = PFGeneralIntegrator(maskmethod='none',geomethod='template_xr',template_xr=sst_data)
     return integrator
     
-@pytest.fixture(autouse=True,scope='module')
+@pytest.fixture()#autouse=True,scope='module')
 def pfesint(sst_data):
     integrator = PFEnergySeriesIntegrator(maskmethod='none',geomethod='template_xr',template_xr=sst_data)
     return integrator
 
-@pytest.fixture(autouse=True,scope='module')
+@pytest.fixture()#autouse=True,scope='module')
 def pfesint_dask(sst_data):
     integrator = PFEnergySeriesIntegrator(maskmethod='none',geomethod='template_xr',template_xr=sst_data,use_chunked_processing=True)
     return integrator
-@pytest.fixture(autouse=True,scope='module')
+@pytest.fixture()#autouse=True,scope='module')
 def pfgenint_dask(sst_data):
     integrator = PFGeneralIntegrator(maskmethod='none',geomethod='template_xr',template_xr=sst_data,use_chunked_processing=True)
     return integrator
@@ -59,7 +59,6 @@ def test_integrator_beamcenter_to_poni(pfesint):
     pfesint.nika_beamcenter_y = 600
     assert(math.isclose(pfesint.poni1,0.029445))
     assert(math.isclose(pfesint.poni2,0.0293916))
-    pass
 
 def test_integration_runs_en_series_legacy_2dim_mi(sst_data,pfesint):
     pfesint.integrateImageStack(sst_data)


### PR DESCRIPTION
Fixes #66 by making the integrator fixtures inside `tests\PFIntegrators.py` have function scope, not module scope, and not be auto-used.  This reduces GitHub Actions runner memory use enough to not trip limits.

In an unversioned but related change, I reduced the cyrsoxs test pack from 800 mb to 20 mb by reducing the number of energies, which should also speed up and reduce resource demand on the testing system.