### PR TITLE
Fixes #27 by creating non-varying params in a more reasonable way

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -677,7 +677,8 @@ class SST1RSoXSDB:
                     dims_to_join.append(md[dim])
                 dim_names_to_join.append(dim)
             except TypeError:
-                dims_to_join.append(np.ones(run.start["num_points"]) * md[dim])
+                print(md[dim])
+                dims_to_join.append([md[dim]] * run.start["num_points"])
                 dim_names_to_join.append(dim)
 
         for key, val in coords.items():

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -677,7 +677,6 @@ class SST1RSoXSDB:
                     dims_to_join.append(md[dim])
                 dim_names_to_join.append(dim)
             except TypeError:
-                print(md[dim])
                 dims_to_join.append([md[dim]] * run.start["num_points"])
                 dim_names_to_join.append(dim)
 


### PR DESCRIPTION
#27 was caused by a weird way that non-varying parameters were being turned into arrays, which would then become indexes/coordinates of the xarray.  This one-line PR changes this to a much more Pythonic way that (bonus) also allows non-numeric types to be used as indexes.