### PR TITLE
SST1RSoXSDB: Dramatically improve the performance of `summarize_run`

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -143,7 +143,7 @@ class SST1RSoXSDB:
         userOutputs: list = [],
         **kwargs,
     ) -> pd.DataFrame:
-        """Search the databroker.client.CatalogOfBlueskyRuns for scans matching all provided keywords and return metadata as a dataframe.
+        """Search the Bluesky catalog for scans matching all provided keywords and return metadata as a dataframe.
 
         Matches are made based on the values in the top level of the 'start' dict within the metadata of each
         entry in the Bluesky Catalog (databroker.client.CatalogOfBlueskyRuns). Based on the search arguments provided,
@@ -203,7 +203,7 @@ class SST1RSoXSDB:
                 e.g., userOutputs = [["Exposure Multiplier","exptime", r'catalog.start'], ["Stop Time","time",r'catalog.stop']]
 
         Returns:
-            pd.Dataframe containing the results of the search, or an empty dataframe if the search fails
+            Pandas dataframe containing the results of the search, or an empty dataframe if the search fails
         """
 
         # Pull in the reference to the databroker.client.CatalogOfBlueskyRuns attribute
@@ -250,10 +250,7 @@ class SST1RSoXSDB:
         # Iterate through search terms sequentially, reducing the size of the catalog based on successful matches
 
         reducedCatalog = bsCatalog
-        loopDesc = "Searching by keyword arguments"
-        for index, searchSeries in tqdm(
-            df_SearchDet.iterrows(), total=df_SearchDet.shape[0], desc=loopDesc
-        ):
+        for searchSeries in tqdm(df_SearchDet.iterrows(), desc = "Searching by keyword arguments"):
 
             # Skip arguments with value None, and quits if the catalog was reduced to 0 elements
             if (searchSeries[1] is not None) and (len(reducedCatalog) > 0):
@@ -299,8 +296,7 @@ class SST1RSoXSDB:
         if (outputType == "scans"):  
             # Branch 2.1, if only scan IDs needed, build and return a 1-column dataframe
             scan_ids = []
-            loopDesc = "Building scan list"
-            for scanEntry in tqdm(reducedCatalog.values(), desc=loopDesc):
+            for scanEntry in tqdm(reducedCatalog.values(), desc = "Building scan list"):
                 scan_ids.append(scanEntry.start["scan_id"])
             return pd.DataFrame(scan_ids, columns=["Scan ID"])
 

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -248,7 +248,7 @@ class SST1RSoXSDB:
         # Iterate through search terms sequentially, reducing the size of the catalog based on successful matches
 
         reducedCatalog = bsCatalog
-        for searchSeries in tqdm(df_SearchDet.iterrows(), desc = "Searching by keyword arguments"):
+        for _,searchSeries in tqdm(df_SearchDet.iterrows(),total = df_SearchDet.shape[0], desc = "Searching by keyword arguments"):
 
             # Skip arguments with value None, and quits if the catalog was reduced to 0 elements
             if (searchSeries[1] is not None) and (len(reducedCatalog) > 0):
@@ -314,8 +314,8 @@ class SST1RSoXSDB:
                 ["sample_id", "sample_id", r"catalog.start", "default"],
                 ["bar_spot", "bar_spot", r"catalog.start", "ext_msmt"],
                 ["plan", "plan_name", r"catalog.start", "default"],
-                ["detector", "RSoXS_Main_DET", r"catalog.start", "default"],
-                ["polarization", "en_polarization_setpoint", r'catalog.start', "default"],
+                ["detector", "RSoXS_Main_DET", r"catalog.start", "default"], 
+                ["polarization", "pol", r'catalog.start["plan_args"]', "default"],
                 ["sample_rotation", "angle", r"catalog.start", "ext_msmt"],
                 ["exit_status", "exit_status", r"catalog.stop", "default"],
                 ["num_Images", "primary", r'catalog.stop["num_events"]', "default"],

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -248,7 +248,7 @@ class SST1RSoXSDB:
         # Iterate through search terms sequentially, reducing the size of the catalog based on successful matches
 
         reducedCatalog = bsCatalog
-        for _,searchSeries in tqdm(df_SearchDet.iterrows(),total = df_SearchDet.shape[0], desc = "Searching by keyword arguments"):
+        for _,searchSeries in tqdm(df_SearchDet.iterrows(),total = df_SearchDet.shape[0], desc = "Running catalog search..."):
 
             # Skip arguments with value None, and quits if the catalog was reduced to 0 elements
             if (searchSeries[1] is not None) and (len(reducedCatalog) > 0):
@@ -304,7 +304,7 @@ class SST1RSoXSDB:
             outputValueLibrary = [
                 ["scan_id", "scan_id", r"catalog.start", "default"],
                 ["uid", "uid", r"catalog.start", "ext_bio"],
-                ["start time", "time", r"catalog.start", "default"],
+                ["start_time", "time", r"catalog.start", "default"],
                 ["cycle", "cycle", r"catalog.start", "default"],
                 ["saf", "SAF", r"catalog.start", "ext_bio"],
                 ["user_name", "user_name", r"catalog.start", "ext_bio"],
@@ -359,7 +359,7 @@ class SST1RSoXSDB:
             outputList = []
 
             # Outer loop: Catalog entries 
-            for scanEntry in tqdm(reducedCatalog.values(),desc = "Building output dataframe"):
+            for scanEntry in tqdm(reducedCatalog.values(),desc = "Retrieving results..."):
                 singleScanOutput = []
 
                 # Pull the start and stop docs once
@@ -376,7 +376,10 @@ class SST1RSoXSDB:
                     metaDataSource = outputEntry[2]
 
                     try:  # Add the metadata value depending on where it is located
-                        if metaDataSource == r"catalog.start":
+                        if metaDataLabel == 'time':
+                            singleScanOutput.append(datetime.datetime.fromtimestamp(currentCatalogStart['time']))
+                            # see Zen of Python # 9,8 for justification
+                        elif metaDataSource == r"catalog.start":
                             singleScanOutput.append(currentCatalogStart[metaDataLabel])
                         elif metaDataSource == r'catalog.start["plan_args"]':
                             singleScanOutput.append(
@@ -408,9 +411,9 @@ class SST1RSoXSDB:
                 
                  
             # Convert to dataframe for export
-            if debugWarnings:
+            if missesDuringLoad:
                             warnings.warn(
-                                f'One or more missing field(s) during this load.  Re-run with debugWarnings=True to see details.',
+                                f'One or more missing field(s) during this load were replaced with "N/A".  Re-run with debugWarnings=True to see details.',
                                     stacklevel=2)
             return pd.DataFrame(outputList, columns=activeOutputLabels)
 


### PR DESCRIPTION
It turns out (after very helpful conversations with @danielballan, thanks!) that one can dramatically speed up iterative fetching of Databroker 2 (Tiled backed) documents by bulk-downloading, for instance:

![image](https://user-images.githubusercontent.com/875623/231043948-f72dc282-4f17-429e-8e74-bc13700e1d83.png)
This PR takes this MCVE and implements it in `SST1RSoXSDB.summarize_run`, a worker function for doing Tiled searches.

Other changes:
- tidies up a lot of the code within this function to improve readability and remove some unnecessary things.
- takes several warnings that are entirely related to input validation errors within the user's control and promotes them to raise a real ValueError.
- adds a flag (default on) that buries *all* "field could not be found" errors behind a single warning.  Otherwise every time metadata changes the output of the function fills a terminal with hundreds of warnings...
- adds a special case so the run start time is returned as a `datetime.datetime` rather than an epoch number.

Resulting performance: a 1184-entry search which used to take 1m 5s now completes in about 14s, filling ~80 runs / second.  In testing tonight (when the Tiled server is under less load) I am seeing performance up to ~120 runs / second.