### PR TITLE
Add documentation on anisotropic ratio and other rsoxs features

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ To play with PyHyperScattering's tutorial notebooks interactively, use Binder:
    source/intro
    source/loading
    source/integration
+   source/rsoxs
    source/learning-to-fly
    source/utilities
    source/modules

--- a/docs/source/rsoxs.rst
+++ b/docs/source/rsoxs.rst
@@ -1,0 +1,11 @@
+PyHyperScattering Tools for RSoXS
+==================================
+
+
+PyHyperScattering provides a variety of tools specific to the RSoXS technique:
+
+
+
+Anisotropic Ratio
+------------------
+


### PR DESCRIPTION
#2 includes features specific to RSoXS such as AR calculation, but has not had any documentation generated for these features (in over two years :/).  This PR adds a first pass at this documentation and a tutorial notebook on using the features.