### PR TITLE
Fixed Error Handling for integrateImage energy

### DIFF
--- a/src/PyHyperScattering/PFEnergySeriesIntegrator.py
+++ b/src/PyHyperScattering/PFEnergySeriesIntegrator.py
@@ -57,7 +57,10 @@ class PFEnergySeriesIntegrator(PFGeneralIntegrator):
                     for i,n in enumerate(img.indexes[multiindex_name].names):
                         if n == 'energy':
                             idx_of_energy = i
-                    en = float(getattr(img,multiindex_name).values[idx_of_energy][0])
+                    try:
+                        en = float(getattr(img,multiindex_name).values[idx_of_energy][0]) # this does not work for 2022-2 data; does it work for other cycles?
+                    except IndexError:
+                        en = float(getattr(img,multiindex_name).values[0][idx_of_energy])
             except KeyError:
                 pass
         if en is not None:


### PR DESCRIPTION
When attempting to integrate data from cycle 2022-2, was getting an IndexError when integrateImageStack called integrateSingleImage.  The indexes for finding the energy were switched from what they needed to be. Perhaps this block of code isn't running for other cycles, or the index structure is different.

Changes are at lines 62 and 63.