### PR TITLE
chore: exclude tutorial, docs, and all ipynb files from linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-tutorial/* linguist-vendored
+tutorial/* linguist-documentation=true
+*.ipynb linguist-documentation=true
+docs/* linguist-documentation=true
 src/PyHyperScattering/_version.py export-subst


### PR DESCRIPTION
This should correctly show language stats as being 100% pure Python.