### PR TITLE
Add CI hooks for `SST1RSoXSDB` testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,7 @@ jobs:
     - name: Cache pip
       uses: actions/cache@v2
       with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
+        path: ${{ env.pythonLocation }}
         # Look to see if there is a cache hit for the corresponding requirements file
         key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,8 @@ jobs:
         C:\msys64\usr\bin\wget.exe https://github.com/usnistgov/PyHyperScattering/releases/download/0.0.0-example-data/CMS_giwaxs_series.zip
         unzip CMS_giwaxs_series.zip
     - name: Test with pytest
+      env: 
+         TILED_API_KEY: ${{ secrets.TILED_API_KEY }}
       run: |
         #pytest -v
         #temporarily disabling coverage for memory usage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
         # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-         ${{ runner.os }}-pip-
+         ${{ runner.os }}-py${{ matrix.python-version }}-pip-
           ${{ runner.os }}-
     - name: Install dependencies
       run: |

--- a/requirements-bluesky.txt
+++ b/requirements-bluesky.txt
@@ -1,2 +1,3 @@
 tiled[all]>=0.1.0a74
 databroker[all]>=2.0.0b10
+bottleneck

--- a/requirements-bluesky.txt
+++ b/requirements-bluesky.txt
@@ -1,2 +1,2 @@
-tiled[client]>=0.1.0a74
+tiled[all]>=0.1.0a74
 databroker[all]>=2.0.0b10

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astropy
 fabio
 h5py
 nodejs
-numpy
+numpy<2
 pandas
 # pygix fails to improt if silx > 2.0.0 
 silx==2.0.0

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -39,7 +39,7 @@ def sstdb():
         import os
         api_key = os.environ['TILED_API_KEY']
         client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
-    sstdb = SST1RSoXSDB(catalog=client['rsoxs'],corr_mode='none')
+    sstdb = SST1RSoXSDB(catalog=client['rsoxs']['raw'],corr_mode='none')
     return sstdb
 
 @must_have_tiled

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -36,7 +36,9 @@ def sstdb():
     try:
         catalog = tiled.client.from_profile('rsoxs')
     except tiled.profiles.ProfileNotFound:
-        catalog = tiled.client.from_uri('https://tiled-demo.blueskyproject.io')['rsoxs']['raw']
+        import os
+        api_key = os.environ['TILED_API_KEY']
+        client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
     sstdb = SST1RSoXSDB(catalog=catalog,corr_mode='none')
     return sstdb
 

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -10,8 +10,9 @@ try:
         SKIP_DB_TESTING=False
     except tiled.profiles.ProfileNotFound:
         try:
-            client = tiled.client.from_uri('https://tiled-demo.blueskyproject.io')
-            SKIP_DB_TESTING=True # waiting on test data to be posted to this server
+            import os
+            api_key = os.environ['TILED_API_KEY']
+            client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
         except Exception:
             SKIP_DB_TESTING=True
 except ImportError:

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -38,8 +38,8 @@ def sstdb():
     except tiled.profiles.ProfileNotFound:
         import os
         api_key = os.environ['TILED_API_KEY']
-        client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
-    sstdb = SST1RSoXSDB(catalog=client['rsoxs']['raw'],corr_mode='none')
+        client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)['rsoxs']['raw']
+    sstdb = SST1RSoXSDB(catalog=client,corr_mode='none')
     return sstdb
 
 @must_have_tiled

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -13,6 +13,7 @@ try:
             import os
             api_key = os.environ['TILED_API_KEY']
             client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
+            SKIP_DB_TESTING=False
         except Exception:
             SKIP_DB_TESTING=True
 except ImportError:

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -34,7 +34,7 @@ must_have_tiled = pytest.mark.skipif(SKIP_DB_TESTING,reason='Connection to Tiled
 @pytest.fixture(autouse=True,scope='module')
 def sstdb():
     try:
-        catalog = tiled.client.from_profile('rsoxs')
+        client = tiled.client.from_profile('rsoxs')
     except tiled.profiles.ProfileNotFound:
         import os
         api_key = os.environ['TILED_API_KEY']

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -39,7 +39,7 @@ def sstdb():
         import os
         api_key = os.environ['TILED_API_KEY']
         client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
-    sstdb = SST1RSoXSDB(catalog=client,corr_mode='none')
+    sstdb = SST1RSoXSDB(catalog=client['rsoxs'],corr_mode='none')
     return sstdb
 
 @must_have_tiled

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -39,7 +39,7 @@ def sstdb():
         import os
         api_key = os.environ['TILED_API_KEY']
         client = tiled.client.from_uri('https://tiled.nsls2.bnl.gov',api_key=api_key)
-    sstdb = SST1RSoXSDB(catalog=catalog,corr_mode='none')
+    sstdb = SST1RSoXSDB(catalog=client,corr_mode='none')
     return sstdb
 
 @must_have_tiled


### PR DESCRIPTION
This PR adds machinery to enable online connections to the BNL Tiled server during testing.  The 4 tests that run against `SST1RSoXSDB` now run in GitHub actions.  More testing against other scans would be a good idea, and this machinery now supports that.