### PR TITLE
Update test_SST1DBLoader.py by testing scan ID 87758

### DIFF
--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -72,7 +72,7 @@ def test_SST1DB_load_snake_scan_explicit_dims(sstdb):
 
 ## This is intended to test a scan that was run at a single energy and two polarizations
 @must_have_tiled
-def test_SST1DB_load_SingleEnergy2Polarizations_scan_legacy_hinted_dims(sstdb):
+def test_SST1DB_load_SingleEnergy2Polarizations_scan_hinted_dims(sstdb):
     run = sstdb.loadRun(87758).unstack('system')
     assert 'energy' in run.indexes
     assert 'polarization' in run.indexes

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -77,7 +77,7 @@ def test_SST1DB_load_SingleEnergy2Polarizations_scan_hinted_dims(sstdb):
     assert 'energy' in run.indexes
     assert 'polarization' in run.indexes
 @must_have_tiled
-def test_SST1DB_load_SingleEnergy2Polarizations_scan_legacy_explicit_dims(sstdb):
+def test_SST1DB_load_SingleEnergy2Polarizations_scan_explicit_dims(sstdb):
     run = sstdb.loadRun(87758,dims=['energy','polarization']).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -72,12 +72,12 @@ def test_SST1DB_load_snake_scan_explicit_dims(sstdb):
 
 ## This is intended to test a scan that was run at a single energy and two polarizations
 @must_have_tiled
-def test_SST1DB_load_single_scan_legacy_hinted_dims(sstdb):
+def test_SST1DB_load_SingleEnergy2Polarizations_scan_legacy_hinted_dims(sstdb):
     run = sstdb.loadRun(87758).unstack('system')
     assert 'energy' in run.indexes
     assert 'polarization' in run.indexes
 @must_have_tiled
-def test_SST1DB_load_single_scan_legacy_explicit_dims(sstdb):
+def test_SST1DB_load_SingleEnergy2Polarizations_scan_legacy_explicit_dims(sstdb):
     run = sstdb.loadRun(87758,dims=['energy','polarization']).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -69,6 +69,21 @@ def test_SST1DB_load_snake_scan_explicit_dims(sstdb):
     assert 'sam_th' in run.indexes
     assert 'polarization' in run.indexes
 
+
+## This is intended to test a scan that was run at a single energy and two polarizations
+@must_have_tiled
+def test_SST1DB_load_single_scan_legacy_hinted_dims(sstdb):
+    run = sstdb.loadRun(87758).unstack('system')
+    assert 'energy' in run.indexes
+    assert 'polarization' in run.indexes
+@must_have_tiled
+def test_SST1DB_load_single_scan_legacy_explicit_dims(sstdb):
+    run = sstdb.loadRun(87758,dims=['energy','polarization']).unstack('system')
+    assert type(run) == xr.DataArray
+    assert 'energy' in run.indexes
+    assert 'polarization' in run.indexes
+
+
 @must_have_tiled
 def test_SST1DB_exposurewarnings(sstdb):
     with pytest.warns(UserWarning, match="Wide Angle CCD Detector is reported as underexposed"):


### PR DESCRIPTION
Added a set of tests for scan ID 87758 to check that the loadRun function continues to work for a more recent scan and that it works for a case in which a single energy and two polarizations are run.

See issue 154 for more details.