### PR TITLE
take mean if len(data.shape) > 3

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -697,7 +697,10 @@ class SST1RSoXSDB:
             data = run["primary"]["data"].read()[md["detector"] + "_image"]
         elif isinstance(data,tiled.client.array.DaskArrayClient):
             data = run["primary"]["data"].read()[md["detector"] + "_image"]
-
+        
+        if len(data.shape) > 3:
+            data = data.mean("dim_0")
+            
         data = data.astype(int)  # convert from uint to handle dark subtraction
 
         if self.dark_subtract:


### PR DESCRIPTION
This appears to solve the importing repeat scans issues. Might want to be revisited in the future or [in this pull request](https://github.com/usnistgov/PyHyperScattering/pull/141) if you'd like to keep the scans discrete.