### PR TITLE
SST1RSoXSDB: Fix #161 by removing Energy and EPU60 from hinted dimension names

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -620,6 +620,10 @@ class SST1RSoXSDB:
                 axis_list = [x for x in axis_list if "saturated" not in x]
                 axis_list = [x for x in axis_list if "under_exposed" not in x]
 
+                # remove hinted Energy and EPU60 items #161
+                axis_list = [x for x in axis_list if "EPU60" not in x]
+                axis_list = [x for x in axis_list if "Energy" not in x]
+                
                 # knock out any known names of scalar counters
                 axis_list = [x for x in axis_list if "Beamstop" not in x]
                 axis_list = [x for x in axis_list if "Current" not in x]


### PR DESCRIPTION
This pull request includes a small change to the `loadRun` method in the `src/PyHyperScattering/SST1RSoXSDB.py` file. The change removes specific items from the `axis_list`.

* [`src/PyHyperScattering/SST1RSoXSDB.py`](diffhunk://#diff-4cdab59b55ec4a508e69fa9f96e5feaa1671021ab2e490a26388768abeafe8b0R623-R626): Removed "EPU60" and "Energy" items from the `axis_list` to address issue #161.