### PR TITLE
Handle non-energy scans that are saturated/underexposed

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1102,8 +1102,11 @@ class SST1RSoXSDB:
                     message += "Wide Angle CCD Detector is reported as underexposed at all energies."
                 else:
                     idx = np.where(md["Wide Angle CCD Detector_under_exposed"])
-                    warning_e = md["energy"][idx]
-                    message += f"Affected energies include: \n{warning_e}"
+                    try:
+                        warning_e = md["energy"][idx]
+                        message += f"Affected energies include: \n{warning_e}"
+                    except Exception:
+                        message += f"Affected frames were {idx}."
                 warnings.warn(message, stacklevel=2)
         else:
             warnings.warn(
@@ -1118,8 +1121,11 @@ class SST1RSoXSDB:
                     message += "\tWide Angle CCD Detector is reported as saturated at all energies."
                 else:
                     idx = np.where(md["Wide Angle CCD Detector_saturated"])
-                    warning_e = md["energy"][idx]
-                    message += f"Affected energies include: \n{warning_e}"
+                    try:
+                        warning_e = md["energy"][idx]
+                        message += f"Affected energies include: \n{warning_e}"
+                    except Exception:
+                        message += f"Affected frames were {idx}."
                 warnings.warn(message, stacklevel=2)
         else:
             warnings.warn(


### PR DESCRIPTION
@delongchamp's saturation detection routine assumes the scan is an energy series, which breaks if you take a spiral/spatial scan.  This adds a `try/except` to handle non-energy scans, not particularly gracefully but good-enough.

* Added a `try-except` block to handle potential exceptions when accessing `md["energy"][idx]` and provide a fallback message indicating affected frames if an exception occurs. [[1]](diffhunk://#diff-4cdab59b55ec4a508e69fa9f96e5feaa1671021ab2e490a26388768abeafe8b0R1105-R1109) [[2]](diffhunk://#diff-4cdab59b55ec4a508e69fa9f96e5feaa1671021ab2e490a26388768abeafe8b0R1124-R1128)