### PR TITLE
Use Docs4NIST with new upload artifacts version

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: usnistgov/Docs4NIST@982d83efe04ce081f163ca906954312b028eb537
+      - uses: usnistgov/Docs4NIST@0.7
         with:
           docs-folder: docs/
           formats: |-

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: usnistgov/Docs4NIST@0.5
+      - uses: usnistgov/Docs4NIST@982d83efe04ce081f163ca906954312b028eb537
         with:
           docs-folder: docs/
           formats: |-


### PR DESCRIPTION
Pins the Docs4NIST version at the[ full SHA of this commit](https://github.com/usnistgov/Docs4NIST/commit/982d83efe04ce081f163ca906954312b028eb537), which updates the version of upload-artifact embedded inside it so that documentation stuff runs again.