### PR TITLE
Relax Holoviews version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ performance = [
     "cupy"
 ]
 ui = [
-    "holoviews==1.16.2",
+    "holoviews",
     "hvplot",
     "matplotlib"
 ]
@@ -68,6 +68,22 @@ test =  [
          "codecov",
          "pylint"
          ]
+all-nogpu = [
+    "tiled[all]>=0.1.0a74",
+    "databroker[all]>=2.0.0b10",
+    "bluesky-tiled-plugins",
+    "bottleneck",
+    "pyopencl",
+    "dask",
+    "holoviews",
+    "hvplot",
+    "sphinx",
+    "pydata_sphinx_theme",
+    "pytest",
+    "black",
+    "codecov",
+    "pylint"
+]
 all = [
     "tiled[all]>=0.1.0a74",
     "databroker[all]>=2.0.0b10",
@@ -76,7 +92,7 @@ all = [
     "pyopencl",
     "dask",
     "cupy",
-    "holoviews==1.16.2",
+    "holoviews",
     "hvplot",
     "sphinx",
     "pydata_sphinx_theme",

--- a/requirements-ui.txt
+++ b/requirements-ui.txt
@@ -1,3 +1,3 @@
-holoviews==1.16.2
+holoviews
 hvplot
 matplotlib


### PR DESCRIPTION
See #163; this relaxes the version pin of Holoviews which may no longer be necessary.