### PR TITLE
Upgraded metadata lookup for backwards compatibility, added option to input metadata manually

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -605,8 +605,7 @@ class SST1RSoXSDB:
             )
 
         md = self.loadMd(run)
-        ## Add manually added metadata to the md dictionary
-        for md_key in md_manual: md[md_key] = md_manual[md_key]
+        md.update(md_manual) ## Add manually added metadata to the md dictionary
 
         monitors = self.loadMonitors(run)
 

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -574,8 +574,7 @@ class SST1RSoXSDB:
         coords={},
         return_dataset=False,
         useMonitorShutterThinning=True,
-        md_manual = {}, ## Manually enter metadata in case it were not written out during a scan or saved to Tiled
-    ):
+     ):
         """
         Loads a run entry from a catalog result into a raw xarray.
 
@@ -689,32 +688,6 @@ class SST1RSoXSDB:
                     except KeyError:
                         pyhyper_axes_to_use.append(x)
                 dims = pyhyper_axes_to_use
-
-        """
-        elif dims == None:
-            # use the dim tols to define the dimensions
-            # dims = []
-            # dim_tols = {'en_polarization': 0.5, 'sam_x': 0.05, 'sam_y':0.05, 'en_energy':0.05, 'exposure': 1., 'sam_th': 0.05} # set the amount dims are allowed to change; could make this user-chosen in the future
-            dims = ['en_energy','time'] # I think this always needs to be an axis due to the way that the integrator is set up
-            dim_tols = {'en_polarization': 0.5, 'sam_x': 0.05, 'sam_y':0.05, 'exposure': 1., 'sam_th': 0.05} # set the amount dims are allowed to change; could make this user-chosen in the future
-            if 'spiral' in md['start']['plan_name']:
-                dims = ['energy','time']
-                dim_tols = {'polarization': 0.5, 'sam_x': 0.05, 'sam_y':0.05, 'exposure': 1., 'sam_th': 0.05} # set the amount dims are allowed to change; could make this user-chosen in the future
-            for k in dim_tols.keys():
-                dim = md[k]
-                dim_std = np.std(dim)
-                if dim_std > dim_tols[k]:
-                    dims.append(k)
-        else: # if the user has already specified the dims; user may frequently specify 'energy' or 'polarization', so just changing that so it's readable to access correct metadata (without en_, they are just setpoints)
-            dims = dims
-            for i in range(0,len(dims)):
-                if dims[i] == 'polarization':
-                    dims[i] = 'en_polarization'
-                if dims[i] == 'energy':
-                    dims[i] = 'en_energy'
-            if len(dims) == 0:
-                raise NotImplementedError('You have not entered any dimensions; please enter at least one, or use None rather than an empty list')
-        """
 
         data = run["primary"]["data"][md["detector"] + "_image"]
         if isinstance(data,tiled.client.array.ArrayClient):

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -62,6 +62,7 @@ class SST1RSoXSDB:
         "polarization": "en_polarization_setpoint",
         "energy": "en_energy_setpoint",
         "exposure": "RSoXS Shutter Opening Time (ms)",  # md['detector']+'_cam_acquire_time'
+        "image_time": "time" ## Modification so that each image has a distinct time
     }
     
     md_secondary_lookup = {
@@ -1152,7 +1153,8 @@ class SST1RSoXSDB:
             warnings.warn(
                 "'Wide Angle CCD Detector_saturated' not found in stream."
             )
-        md["epoch"] = md["meas_time"].timestamp()
+       ## Modification so that each image has a distinct time
+       md["epoch"] = md["image_time"].timestamp()  #md["epoch"] = md["meas_time"].timestamp()
 
         try:
             md["wavelength"] = 1.239842e-6 / md["energy"]

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -53,6 +53,8 @@ class SST1RSoXSDB:
     }
     md_secondary_lookup = {
         "energy": "en_monoen_setpoint",
+        "sam_x": "manipulator_x",
+        "sam_y": "manipulator_y",
     }
 
     def __init__(

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1057,7 +1057,7 @@ class SST1RSoXSDB:
                 if "_image" not in key:
                     mdLookup[key] = [key]
         ## Find metadata from Tiled and store in PyHyperScattering metadata dictionary
-        for keyName_PHS, keyNames_Beamline in mdLookup.items()
+        for keyName_PHS, keyNames_Beamline in mdLookup.items():
             for keyName_Beamline in keyNames_Beamline:
                 if ((copy.deepcopy(md).get(keyName_PHS, "Key does not exist") != "Key does not exist")
                     and (md[keyName_PHS] is not None)): 

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1113,7 +1113,7 @@ class SST1RSoXSDB:
                             )
                             md[phs] = None
         ## Modification so that each image has a distinct time
-        md["epoch"] = md["image_time"].timestamp() 
+        md["epoch"] = md["image_time"]
         #md["epoch"] = md["meas_time"].timestamp()
 
         # looking at exposure tests in the stream and issuing warnings
@@ -1155,9 +1155,6 @@ class SST1RSoXSDB:
             warnings.warn(
                 "'Wide Angle CCD Detector_saturated' not found in stream."
             )
-        ## Modification so that each image has a distinct time
-        md["epoch"] = md["image_time"].timestamp()
-        #md["epoch"] = md["meas_time"].timestamp()
 
         try:
             md["wavelength"] = 1.239842e-6 / md["energy"]

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -20,8 +20,10 @@ try:
     from httpx import HTTPStatusError
     import tiled
     import dask
-    try: from bluesky_tiled_plugins.queries import RawMongo, Key, FullText, Contains, Regex ## Intended to handle database navigation for 2025 onwards
-    except ImportError: from databroker.queries import RawMongo, Key, FullText, Contains, Regex
+    try: 
+        from bluesky_tiled_plugins.queries import RawMongo, Key, FullText, Contains, Regex # Bluesky changed the location of these queries in 2025, this is new location
+    except ImportError: 
+        from databroker.queries import RawMongo, Key, FullText, Contains, Regex # old location, in case dependencies aren't updated
 except Exception:
     print(
         "Imports failed.  Are you running on a machine with proper libraries for tiled, etc.?"

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1071,7 +1071,7 @@ class SST1RSoXSDB:
                         ):
                             baselineValue = baselineValue.read() ## For tiled_client.array data types, need to use .read() to get the values
                         md[keyName_PHS] = baselineValue.mean()
-                        if baselineValue.var() > 0:
+                        if baselineValue.var() > 0: ## Might need to increase tolerance, so that it does not throw unnecessary warnings for small variations
                             warnings.warn(
                                 (
                                     f"While loading {keyName_Beamline} to infill metadata entry for {keyName_PHS}, found beginning and end values unequal: {baselineValue}.  It is possible something is messed up."

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1088,7 +1088,7 @@ class SST1RSoXSDB:
                     stacklevel=2,
                 )
                         
-        md["epoch"] = md["meas_time"].timestamp() ## Intended to classify all data that belongs to a single scan
+        md["epoch"] = md["meas_time"].timestamp() # Epoch = the time the entire run started, used for multi-scan stacking
 
         # looking at exposure tests in the stream and issuing warnings
         if "Wide Angle CCD Detector_under_exposed" in md:

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1066,11 +1066,7 @@ class SST1RSoXSDB:
                 except (KeyError, HTTPStatusError):
                     try:
                         baseline_value = baseline[key_name_beamline] ## Next, try finding metadata in baseline
-                        if (
-                            type(baseline_value) == tiled.client.array.ArrayClient
-                            or type(baseline_value) == tiled.client.array.DaskArrayClient
-                        ):
-                            baseline_value = baseline_value.read() ## For tiled_client.array data types, need to use .read() to get the values
+                        if isinstance(baseline_value, (tiled.client.array.ArrayClient, tiled.client.array.DaskArrayClient)): baseline_value = baseline_value.read() ## For tiled_client.array data types, need to use .read() to get the values
                         md[key_name_PHS] = baseline_value.mean()
                         if baseline_value.var() > 0: ## Might need to increase tolerance, so that it does not throw unnecessary warnings for small variations
                             warnings.warn(

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -762,7 +762,8 @@ class SST1RSoXSDB:
         # handle the edge case of a partly-finished scan
         if len(index) != len(data["time"]):
             index = index[: len(data["time"])]
-        actual_exposure = md["exposure"] * len(data.dim_0)
+        ## This is a short-term deletion for troubleshooting purposes
+        #actual_exposure = md["exposure"] * len(data.dim_0)
         mindex_coords = xr.Coordinates.from_pandas_multiindex(index, 'system')
         retxr = (
             data.sum("dim_0")

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -63,6 +63,7 @@ class SST1RSoXSDB:
         "polarization": ["en_polarization_setpoint",
                         ],
         "energy": ["en_energy_setpoint",
+                   "en_monoen_setpoint",
                   ],
         "exposure": ["RSoXS Shutter Opening Time (ms)", 
                     ],

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -767,7 +767,6 @@ class SST1RSoXSDB:
         # handle the edge case of a partly-finished scan
         if len(index) != len(data["time"]):
             index = index[: len(data["time"])]
-        actual_exposure = md["exposure"] * len(data.dim_0)
         mindex_coords = xr.Coordinates.from_pandas_multiindex(index, 'system')
         retxr = (
             data.sum("dim_0")
@@ -803,9 +802,13 @@ class SST1RSoXSDB:
             )
         retxr.attrs.update(md)
 
-        retxr.attrs["exposure"] = (
-            len(data.dim_0) * retxr.attrs["exposure"]
-        )  # patch for multi exposures
+        exposure = retxr.attrs.get("exposure")
+        
+        if exposure is not None:
+            retxr.attrs["exposure"] = len(data.dim_0) * exposure
+        else:
+            retxr.attrs["exposure"] = None  # or 0, or skip setting it  # patch for multi exposures
+        
         # now do corrections:
         frozen_attrs = retxr.attrs
         if self.corr_mode == "i0":

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -572,7 +572,7 @@ class SST1RSoXSDB:
         coords={},
         return_dataset=False,
         useMonitorShutterThinning=True,
-        exposure_manual = 1, ## TODO:  Short-term addition for troubleshooting
+        mdManual = {}, ## In case certain metadata were not written out during a scan
     ):
         """
         Loads a run entry from a catalog result into a raw xarray.
@@ -603,7 +603,11 @@ class SST1RSoXSDB:
             )
 
         md = self.loadMd(run)
-        md["exposure"] = exposure_manual ## TODO: short-term troubleshooting.  This is exposure time
+        ## TODO: This is possibly duplicating something that already exists, but it is a temporary fix for now
+        for mdKey in md:
+            if md[mdKey] is None:
+                try: md[mdKey] = mdManual[mdKey]
+                except KeyError: pass
 
         monitors = self.loadMonitors(run)
 

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -572,6 +572,7 @@ class SST1RSoXSDB:
         coords={},
         return_dataset=False,
         useMonitorShutterThinning=True,
+        exposure_manual = 1, ## TODO:  Short-term addition for troubleshooting
     ):
         """
         Loads a run entry from a catalog result into a raw xarray.
@@ -602,6 +603,7 @@ class SST1RSoXSDB:
             )
 
         md = self.loadMd(run)
+        md["exposure"] = exposure_manual ## TODO: short-term troubleshooting
 
         monitors = self.loadMonitors(run)
 
@@ -763,7 +765,7 @@ class SST1RSoXSDB:
         if len(index) != len(data["time"]):
             index = index[: len(data["time"])]
         ## This is a short-term deletion for troubleshooting purposes
-        #actual_exposure = md["exposure"] * len(data.dim_0)
+        actual_exposure = md["exposure"] * len(data.dim_0)
         mindex_coords = xr.Coordinates.from_pandas_multiindex(index, 'system')
         retxr = (
             data.sum("dim_0")

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -606,7 +606,7 @@ class SST1RSoXSDB:
             )
 
         md = self.loadMd(run)
-        md.update(md_manual) ## Add manually added metadata to the md dictionary
+       
 
         monitors = self.loadMonitors(run)
 
@@ -669,7 +669,6 @@ class SST1RSoXSDB:
 
                 # next, construct the reverse lookup table - best mapping we can make of key to pyhyper word
                 # we start with the lookup table used by loadMd()
-                reverse_lut = {}
                 reverse_lut = {md_key_beamline: md_key_PHS 
                                for md_key_PHS, md_key_beamline_list in self.md_lookup.items() 
                                for md_key_beamline in md_key_beamline_list}
@@ -780,7 +779,7 @@ class SST1RSoXSDB:
         exposure = retxr.attrs.get("exposure")
         
         if exposure is not None:
-            retxr.attrs["exposure"] = len(data.dim_0) * exposure
+            retxr.attrs["exposure"] = (len(data.dim_0) * exposure)
         else:
             retxr.attrs["exposure"] = None  # or 0, or skip setting it  # patch for multi exposures
         

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1051,7 +1051,8 @@ class SST1RSoXSDB:
         md_lookup = copy.deepcopy(self.md_lookup)
         ## Add additional metadata not included in lookup dictionary
         md_key_names_beamline = []
-        for key in md_lookup.keys(): md_key_names_beamline = md_key_names_beamline + md_lookup[key] ## Making single list with all historical keys to check if they are in primary
+        for key in md_lookup.keys(): # Make a single list with all historical keys, in the order to check for them.
+            md_key_names_beamline = md_key_names_beamline + md_lookup[key] 
         for key in primary.keys():
             if key not in md_key_names_beamline:
                 if "_image" not in key:

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -42,7 +42,7 @@ class SST1RSoXSDB:
     pix_size_1 = 0.06
     pix_size_2 = 0.06
 
-    ## List of metadata key names used historically at SST1 RSoXS
+    # List of metadata key names used historically at SST1 RSoXS
     md_lookup = {
         "sam_x": ["solid_sample_x",
                   "manipulator_x", ## Started using ~January 2025

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1053,7 +1053,7 @@ class SST1RSoXSDB:
         mdKeyNames_Beamline = []
         for key in mdLookup.keys(): mdKeyNames_Beamline = mdKeyNames_Beamline + mdLookup[key] ## Making single list with all historical keys to check if they are in primary
         for key in primary.keys():
-            if key not in mdKeyNames_Beamline.values():
+            if key not in mdKeyNames_Beamline:
                 if "_image" not in key:
                     mdLookup[key] = [key]
         ## Find metadata from Tiled and store in PyHyperScattering metadata dictionary

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -52,10 +52,12 @@ class SST1RSoXSDB:
                   "manipulator_y", ## Started using ~January 2025
                   "RSoXS Sample Up-Down",
                  ],
-        "sam_z": ["manipulator_z", ## Started using ~January 2025
+        "sam_z": ["solid_sample_z",
+                  "manipulator_z", ## Started using ~January 2025
                   "RSoXS Sample Downstream-Upstream",
                  ],
-        "sam_th": ["manipulator_r", ## Started using ~January 2025
+        "sam_th": ["solid_sample_r",
+                   "manipulator_r", ## Started using ~January 2025
                    "RSoXS Sample Rotation",
                   ],
         "polarization": ["en_polarization_setpoint",

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1057,13 +1057,14 @@ class SST1RSoXSDB:
             if key not in md_key_names_beamline:
                 if "_image" not in key:
                     md_lookup[key] = [key]
-        ## Find metadata from Tiled and store in PyHyperScattering metadata dictionary
-        for key_name_PHS, key_names_beamline in md_lookup.items():
-            for key_name_beamline in key_names_beamline:
+        # Find metadata from Tiled primary and store in PyHyperScattering metadata dictionary
+        for key_name_PHS, key_names_beamline in md_lookup.items(): # first iterate over PyHyper 'words' and ordered lists to check
+            for key_name_beamline in key_names_beamline: # next, go through that list in order
                 if (key_name_PHS in md
                     and md[key_name_PHS] is not None): 
-                    continue ## If the md is already filled in, no need to try other beamline keys
-                try: md[key_name_PHS] = primary[key_name_beamline].read() ## First try finding metadata in primary stream
+                    break # If the pyhyper key is already filled in, no need to try other beamline keys, so stop processing this PyHyper key.
+                try: 
+                    md[key_name_PHS] = primary[key_name_beamline].read() # first try finding metadata in primary stream
                 except (KeyError, HTTPStatusError):
                     try:
                         baseline_value = baseline[key_name_beamline] ## Next, try finding metadata in baseline

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1073,12 +1073,12 @@ class SST1RSoXSDB:
                             baselineValue = baselineValue.read() ## For tiled_client.array data types, need to use .read() to get the values
                         md[keyName_PHS] = baselineValue.mean()
                         if baselineValue.var() > 0:
-                        warnings.warn(
-                            (
-                                f"While loading {keyNames_Beamline} to infill metadata entry for {keyName_PHS}, found beginning and end values unequal: {baseline[keyName_Beamline]}.  It is possible something is messed up."
-                            ),
-                            stacklevel=2,
-                        )
+                            warnings.warn(
+                                (
+                                    f"While loading {keyNames_Beamline} to infill metadata entry for {keyName_PHS}, found beginning and end values unequal: {baseline[keyName_Beamline]}.  It is possible something is messed up."
+                                ),
+                                stacklevel=2,
+                            )
                     except (KeyError, HTTPStatusError): md[keyName_PHS] = None
                 if md[keyName_PHS] is None:
                     warnings.warn(

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -42,6 +42,7 @@ class SST1RSoXSDB:
     pix_size_1 = 0.06
     pix_size_2 = 0.06
 
+    """
     md_lookup = {
         "sam_x": "RSoXS Sample Outboard-Inboard",
         "sam_y": "RSoXS Sample Up-Down",
@@ -51,6 +52,17 @@ class SST1RSoXSDB:
         "energy": "en_energy_setpoint",
         "exposure": "RSoXS Shutter Opening Time (ms)",  # md['detector']+'_cam_acquire_time'
     }
+    """
+    md_lookup = {
+        "sam_x": "manipulator_x",
+        "sam_y": "manipulator_y",
+        "sam_z": "manipulator_z",
+        "sam_th": "manipulator_r",
+        "polarization": "en_polarization_setpoint",
+        "energy": "en_energy_setpoint",
+        "exposure": "RSoXS Shutter Opening Time (ms)",  # md['detector']+'_cam_acquire_time'
+    }
+    
     md_secondary_lookup = {
         "energy": "en_monoen_setpoint",
         "sam_x": "manipulator_x",

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1058,8 +1058,8 @@ class SST1RSoXSDB:
         ## Find metadata from Tiled and store in PyHyperScattering metadata dictionary
         for keyName_PHS, keyNames_Beamline in mdLookup.items():
             for keyName_Beamline in keyNames_Beamline:
-                if ((copy.deepcopy(md).get(keyName_PHS, "Key does not exist") != "Key does not exist")
-                    and (md[keyName_PHS] is not None)): 
+                if (keyName_PHS in md
+                    and md[keyName_PHS] is not None): 
                     continue ## If the md is already filled in, no need to try other beamline keys
                 try: md[keyName_PHS] = primary[keyName_Beamline].read() ## First try finding metadata in primary stream
                 except (KeyError, HTTPStatusError):

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1067,7 +1067,7 @@ class SST1RSoXSDB:
                     try:
                         baseline_value = baseline[key_name_beamline] ## Next, try finding metadata in baseline
                         if isinstance(baseline_value, (tiled.client.array.ArrayClient, tiled.client.array.DaskArrayClient)): baseline_value = baseline_value.read() ## For tiled_client.array data types, need to use .read() to get the values
-                        md[key_name_PHS] = baseline_value.mean()
+                        md[key_name_PHS] = baseline_value.mean().round(4) ## Rounded for stacking purposes.  The EPICS values recorded in bluesky are read back from encoders, and are not 100% reproducible. If you try to load a spiral scan for instance, and you don't round, the scan will be massive because it won't be on a regular grid - because one frame was taken at sam_x = 128.0000034 and the next one up was taken at sam_x = 128.0000055.
                         if baseline_value.var() > 0: ## Might need to increase tolerance, so that it does not throw unnecessary warnings for small variations
                             warnings.warn(
                                 (

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -669,9 +669,9 @@ class SST1RSoXSDB:
                 # next, construct the reverse lookup table - best mapping we can make of key to pyhyper word
                 # we start with the lookup table used by loadMd()
                 reverse_lut = {}
-                for mdKey_PHS in self.md_lookup.keys():
-                    for mdKey_Beamline in self.md_lookup[mdKey_PHS]:
-                        reverse_lut[mdKey_Beamline] = mdKey_PHS
+                reverse_lut = {md_key_beamline: md_key_PHS 
+                               for md_key_PHS, md_key_beamline_list in self.md_lookup.items() 
+                               for md_key_beamline in md_key_beamline_list}
 
                 # here, we broaden the table to make a value that default sources from '_setpoint' actually match on either
                 # the bare value or the readback value.

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -672,7 +672,7 @@ class SST1RSoXSDB:
                 reverse_lut = {md_key_beamline: md_key_PHS 
                                for md_key_PHS, md_key_beamline_list in self.md_lookup.items() 
                                for md_key_beamline in md_key_beamline_list}
-
+# this creates a reverse mapping where the keys are the possible names in 'beamline language' of a parameter, and the values are the name in 'PyHyper language'.  This exploits the fact that dicts are ordered to provide rank-sorted mapping of parameters.
                 # here, we broaden the table to make a value that default sources from '_setpoint' actually match on either
                 # the bare value or the readback value.
                 reverse_lut_adds = {}

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -53,6 +53,7 @@ class SST1RSoXSDB:
         "exposure": "RSoXS Shutter Opening Time (ms)",  # md['detector']+'_cam_acquire_time'
     }
     """
+    ## TODO: This is a temporary fix.  Need to understand better how this is being used to see if there is a more organized try/except script I can use to handle the different metadata key names over time.
     md_lookup = {
         "sam_x": "manipulator_x",
         "sam_y": "manipulator_y",

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -46,20 +46,20 @@ class SST1RSoXSDB:
 
     # List of metadata key names used historically at SST1 RSoXS
     md_lookup = {
-        "sam_x": ["solid_sample_x",
-                  "manipulator_x", ## Started using ~January 2025
+        "sam_x": ["solid_sample_x", # Started using ~March 2025
+                  "manipulator_x", # Started using ~January 2025
                  "RSoXS Sample Outboard-Inboard",
                  ],
-        "sam_y": ["solid_sample_y",
-                  "manipulator_y", ## Started using ~January 2025
+        "sam_y": ["solid_sample_y", # Started using ~March 2025
+                  "manipulator_y", # Started using ~January 2025
                   "RSoXS Sample Up-Down",
                  ],
-        "sam_z": ["solid_sample_z",
-                  "manipulator_z", ## Started using ~January 2025
+        "sam_z": ["solid_sample_z", # Started using ~March 2025
+                  "manipulator_z", # Started using ~January 2025
                   "RSoXS Sample Downstream-Upstream",
                  ],
-        "sam_th": ["solid_sample_r",
-                   "manipulator_r", ## Started using ~January 2025
+        "sam_th": ["solid_sample_r", # Started using ~March 2025
+                   "manipulator_r", # Started using ~January 2025
                    "RSoXS Sample Rotation",
                   ],
         "polarization": ["en_polarization_setpoint",

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -605,10 +605,7 @@ class SST1RSoXSDB:
 
         md = self.loadMd(run)
         ## Add manually added metadata to the md dictionary
-        for mdKey in md:
-            if md[mdKey] is None:
-                try: md[mdKey] = mdManual[mdKey]
-                except KeyError: pass
+        for mdKey in mdManual: md[mdKey] = mdManual[mdKey]
 
         monitors = self.loadMonitors(run)
 
@@ -1019,9 +1016,9 @@ class SST1RSoXSDB:
                 md["beamcenter_y"] = 549.76
                 md["sdd"] = 34.5  # GUESS; SOMEONE SHOULD CONFIRM WITH A BCP MAYBE??
             else:
-                md["beamcenter_x"] = run.start["RSoXS_WAXS_BCX"]  # 399 #
-                md["beamcenter_y"] = run.start["RSoXS_WAXS_BCY"]  # 526
-                md["sdd"] = run.start["RSoXS_WAXS_SDD"]
+                md["beamcenter_x"] = 467.5#run.start["RSoXS_WAXS_BCX"]  # 399 #
+                md["beamcenter_y"] = 513.4 #run.start["RSoXS_WAXS_BCY"]  # 526
+                md["sdd"] = 39.19#run.start["RSoXS_WAXS_SDD"]
 
         else:
             md["rsoxs_config"] = "unknown"

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1112,7 +1112,9 @@ class SST1RSoXSDB:
                                 stacklevel=2,
                             )
                             md[phs] = None
-        md["epoch"] = md["meas_time"].timestamp()
+        ## Modification so that each image has a distinct time
+        md["epoch"] = md["image_time"].timestamp() 
+        #md["epoch"] = md["meas_time"].timestamp()
 
         # looking at exposure tests in the stream and issuing warnings
         if "Wide Angle CCD Detector_under_exposed" in md:
@@ -1153,8 +1155,9 @@ class SST1RSoXSDB:
             warnings.warn(
                 "'Wide Angle CCD Detector_saturated' not found in stream."
             )
-       ## Modification so that each image has a distinct time
-       md["epoch"] = md["image_time"].timestamp()  #md["epoch"] = md["meas_time"].timestamp()
+        ## Modification so that each image has a distinct time
+        md["epoch"] = md["image_time"].timestamp()
+        #md["epoch"] = md["meas_time"].timestamp()
 
         try:
             md["wavelength"] = 1.239842e-6 / md["energy"]

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -62,7 +62,7 @@ class SST1RSoXSDB:
                   ],
         "exposure": ["RSoXS Shutter Opening Time (ms)", 
                     ],
-        "timestamp": ["time",
+        "time": ["time",
                      ],
     }
     
@@ -1044,8 +1044,7 @@ class SST1RSoXSDB:
             primary = run["primary"]["data"]
         except (KeyError, HTTPStatusError):
             raise Exception(
-                "No primary stream --> probably you caught run before image was written.  Try"
-                " again."
+                "No primary stream --> probably you caught run before image was written.  Try again."
             )
 
         mdLookup = copy.deepcopy(self.mdLookup)
@@ -1075,18 +1074,18 @@ class SST1RSoXSDB:
                         if baselineValue.var() > 0:
                             warnings.warn(
                                 (
-                                    f"While loading {keyNames_Beamline} to infill metadata entry for {keyName_PHS}, found beginning and end values unequal: {baseline[keyName_Beamline]}.  It is possible something is messed up."
+                                    f"While loading {keyName_Beamline} to infill metadata entry for {keyName_PHS}, found beginning and end values unequal: {baselineValue}.  It is possible something is messed up."
                                 ),
                                 stacklevel=2,
                             )
                     except (KeyError, HTTPStatusError): md[keyName_PHS] = None
-                if md[keyName_PHS] is None:
-                    warnings.warn(
-                        (
-                            f"Could not find {keyNames_Beamline} in either baseline or primary. Setting {keyName_PHS} to None.  Can be entered manually."
-                        ),
-                        stacklevel=2,
-                    )
+            if md[keyName_PHS] is None:
+                warnings.warn(
+                    (
+                        f"Could not find {keyNames_Beamline} in either baseline or primary. Setting {keyName_PHS} to None.  Can be entered manually."
+                    ),
+                    stacklevel=2,
+                )
                         
         md["epoch"] = md["meas_time"].timestamp() ## Intended to classify all data that belongs to a single scan
 

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -603,7 +603,7 @@ class SST1RSoXSDB:
             )
 
         md = self.loadMd(run)
-        md["exposure"] = exposure_manual ## TODO: short-term troubleshooting
+        md["exposure"] = exposure_manual ## TODO: short-term troubleshooting.  This is exposure time
 
         monitors = self.loadMonitors(run)
 
@@ -764,7 +764,6 @@ class SST1RSoXSDB:
         # handle the edge case of a partly-finished scan
         if len(index) != len(data["time"]):
             index = index[: len(data["time"])]
-        ## This is a short-term deletion for troubleshooting purposes
         actual_exposure = md["exposure"] * len(data.dim_0)
         mindex_coords = xr.Coordinates.from_pandas_multiindex(index, 'system')
         retxr = (

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1000,7 +1000,7 @@ class SST1RSoXSDB:
                 md["beamcenter_y"] = run.start["RSoXS_SAXS_BCY"]
                 md["sdd"] = run.start["RSoXS_SAXS_SDD"]
 
-        elif start["RSoXS_Config"] == "WAXS":
+        elif "WAXS" in start["RSoXS_Config"]:
             md["rsoxs_config"] = "waxs"
             if (meas_time > datetime.datetime(2020, 11, 16)) and (
                 meas_time < datetime.datetime(2021, 1, 15)
@@ -1016,9 +1016,9 @@ class SST1RSoXSDB:
                 md["beamcenter_y"] = 549.76
                 md["sdd"] = 34.5  # GUESS; SOMEONE SHOULD CONFIRM WITH A BCP MAYBE??
             else:
-                md["beamcenter_x"] = 467.5#run.start["RSoXS_WAXS_BCX"]  # 399 #
-                md["beamcenter_y"] = 513.4 #run.start["RSoXS_WAXS_BCY"]  # 526
-                md["sdd"] = 39.19#run.start["RSoXS_WAXS_SDD"]
+                md["beamcenter_x"] = run.start["RSoXS_WAXS_BCX"]  # 399 #
+                md["beamcenter_y"] = run.start["RSoXS_WAXS_BCY"]  # 526
+                md["sdd"] = run.start["RSoXS_WAXS_SDD"]
 
         else:
             md["rsoxs_config"] = "unknown"

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -44,10 +44,12 @@ class SST1RSoXSDB:
 
     ## List of metadata key names used historically at SST1 RSoXS
     mdLookup = {
-        "sam_x": ["manipulator_x", ## Started using ~January 2025
+        "sam_x": ["solid_sample_x",
+                  "manipulator_x", ## Started using ~January 2025
                  "RSoXS Sample Outboard-Inboard",
                  ],
-        "sam_y": ["manipulator_y", ## Started using ~January 2025
+        "sam_y": ["solid_sample_y",
+                  "manipulator_y", ## Started using ~January 2025
                   "RSoXS Sample Up-Down",
                  ],
         "sam_z": ["manipulator_z", ## Started using ~January 2025

--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -1075,7 +1075,7 @@ class SST1RSoXSDB:
                         if baseline_value.var() > 0: ## Might need to increase tolerance, so that it does not throw unnecessary warnings for small variations
                             warnings.warn(
                                 (
-                                    f"While loading {key_name_beamline} to infill metadata entry for {key_name_PHS}, found beginning and end values unequal: {baseline_value}.  It is possible something is messed up."
+                                    f"While loading {key_name_beamline} to infill metadata entry for {key_name_PHS}, found values before and after measurement unequal: {baseline_value}.  This might be a problem for data reliability."
                                 ),
                                 stacklevel=2,
                             )

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -87,21 +87,21 @@ def test_SST1DB_load_SingleEnergy2Polarizations_scan_explicit_dims(sstdb):
 
 @must_have_tiled
 def test_SST1DB_load_energy_scan_20241209(sstdb):
-    run = sstdb.loadRun(91175,dims=['energy','polarization']).unstack('system')
+    run = sstdb.loadRun(91175).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
     assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_load_energy_scan_20250213(sstdb):
-    run = sstdb.loadRun(92202,dims=['energy','polarization']).unstack('system')
+    run = sstdb.loadRun(92202).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
     assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_load_spiral_scan_20250221(sstdb):
-    run = sstdb.loadRun(92770,dims=['sam_x','sam_y']).unstack('system')
+    run = sstdb.loadRun(92770).unstack('system')
     assert type(run) == xr.DataArray
     assert 'sam_x' in run.indexes
     assert 'sam_y' in run.indexes
@@ -115,7 +115,7 @@ def test_SST1DB_load_count_scan_20250222(sstdb):
 
 @must_have_tiled
 def test_SST1DB_load_energy_scan_20250223(sstdb):
-    run = sstdb.loadRun(93065,dims=['energy','polarization']).unstack('system')
+    run = sstdb.loadRun(93065).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
     assert 'polarization' in run.indexes

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -84,6 +84,35 @@ def test_SST1DB_load_SingleEnergy2Polarizations_scan_explicit_dims(sstdb):
     assert 'polarization' in run.indexes
 
 
+
+@must_have_tiled
+def test_SST1DB_load_energy_scan_20241209(sstdb):
+    run = sstdb.loadRun(91175,dims=['energy','polarization']).unstack('system')
+    assert type(run) == xr.DataArray
+    assert 'energy' in run.indexes
+    assert 'polarization' in run.indexes
+
+@must_have_tiled
+def test_SST1DB_load_energy_scan_20250213(sstdb):
+    run = sstdb.loadRun(92202,dims=['energy','polarization']).unstack('system')
+    assert type(run) == xr.DataArray
+    assert 'energy' in run.indexes
+    assert 'polarization' in run.indexes
+
+@must_have_tiled
+def test_SST1DB_load_count_scan_20250222(sstdb):
+    run = sstdb.loadRun(92849,dims=['time','polarization']).unstack('system')
+    assert type(run) == xr.DataArray
+    assert 'time' in run.indexes
+    assert 'polarization' in run.indexes
+
+@must_have_tiled
+def test_SST1DB_load_energy_scan_20250223(sstdb):
+    run = sstdb.loadRun(93065,dims=['energy','polarization']).unstack('system')
+    assert type(run) == xr.DataArray
+    assert 'energy' in run.indexes
+    assert 'polarization' in run.indexes
+
 @must_have_tiled
 def test_SST1DB_exposurewarnings(sstdb):
     with pytest.warns(UserWarning, match="Wide Angle CCD Detector is reported as underexposed"):

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -97,7 +97,6 @@ def test_SST1DB_load_energy_scan_20250213(sstdb):
     run = sstdb.loadRun(92202).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
-    assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_load_spiral_scan_20250221(sstdb):
@@ -118,7 +117,6 @@ def test_SST1DB_load_energy_scan_20250223(sstdb):
     run = sstdb.loadRun(93065).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
-    assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_exposurewarnings(sstdb):

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -100,6 +100,13 @@ def test_SST1DB_load_energy_scan_20250213(sstdb):
     assert 'polarization' in run.indexes
 
 @must_have_tiled
+def test_SST1DB_load_spiral_scan_20250221(sstdb):
+    run = sstdb.loadRun(92770,dims=['sam_x','sam_y']).unstack('system')
+    assert type(run) == xr.DataArray
+    assert 'sam_x' in run.indexes
+    assert 'sam_y' in run.indexes
+
+@must_have_tiled
 def test_SST1DB_load_count_scan_20250222(sstdb):
     run = sstdb.loadRun(92849,dims=['time','polarization']).unstack('system')
     assert type(run) == xr.DataArray


### PR DESCRIPTION
Addresses issue #178.

`mdLookup` dictionary was updated so that beamline metaddata key names can be entered as a list instead of single value (or two values in the case of `secondary_lookup table`).  Sets up infrastructure for backwards compatibility with respect to key names used historically at the beamline.  `secondary_lookup` dictionary was removed, as all historical key names are consolidated into `mdLookup`.  These changes were propagated to the code where Tiled is searched for metadata keys as well as in the construction of reverse lookup table (`reverse_lut`) in `loadRun`.  These changes were tested for scan IDs 92849, 93065, and 91175, which include scans from before and after the beamline codebase upgrades in January 2025.

```
Loader = phs.load.SST1RSoXSDB(corr_mode="none")

scanID = 92849 ## Count scan with 50 repeats at constant energy and polarization
#scanID = 93065 ## RSoXS energy scan with 1 repeat post-January 2025
#scanID = 91175 ## RSoXS energy scan with 1 repeat December 2024

scan = Loader.loadRun(scanID, dims=["time", "energy", "polarization"]).unstack('system')
scan
```

Also tested the following:
```
scanID_spiral = 92770

scan = loader.loadRun(scanID_spiral, dims=['sam_x','sam_y']).unstack('system')
scan
```

Additionally, `mdManual` input was added into `loadRun` function so that metadata values can be entered manually in case they were not originally written out with the scan.  My understanding is that the current `coords` input cannot take more qualitative single-value entries (e.g., `{"sample_notes": "details"}`) that are meant to be stored in `attrs`.  If it makes sense, I could think of how to consolidate these two inputs.