### PR TITLE
Make pygix an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ all = [
     "cupy",
     "holoviews==1.16.2",
     "hvplot",
+    "silx==2.0.0",
     "sphinx",
     "pydata_sphinx_theme",
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,12 +36,14 @@ dependencies = [
     "fabio",
     "nodejs",
     "silx==2.0.0",
-    "pygix",
     "pydata_sphinx_theme",
     "numexpr<2.8.5",
 ]
 
 [project.optional-dependencies]
+grazing = [
+    "pygix"
+    ]
 bluesky = [
     "tiled[all]>=0.1.0a74",
     "databroker[all]>=2.0.0b10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ all = [
     "databroker[all]>=2.0.0b10",
     "bluesky-tiled-plugins",
     "bottleneck",
+    "pygix",
     "pyopencl",
     "dask",
     "cupy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,13 @@ dependencies = [
     "astropy",
     "fabio",
     "nodejs",
-    "silx==2.0.0",
     "pydata_sphinx_theme",
     "numexpr<2.8.5",
 ]
 
 [project.optional-dependencies]
-grazing = [
+grazing = [    
+    "silx==2.0.0",
     "pygix"
     ]
 bluesky = [

--- a/src/PyHyperScattering/PGGeneralIntegrator.py
+++ b/src/PyHyperScattering/PGGeneralIntegrator.py
@@ -9,12 +9,15 @@ File to:
 # Imports
 import xarray as xr
 import numpy as np
-import pygix  # type: ignore
 import pathlib
 from typing import Union, Tuple
 from tqdm.auto import tqdm 
 import warnings
 from PyHyperScattering.PFGeneralIntegrator import PFGeneralIntegrator
+try:
+    import pygix  # type: ignore
+except ImportError:
+    warnings.warn('Unable to load optional dependency pygix, needed for grazing.  Install with pyhyperscattering[grazing] if needed.',stacklevel=2)
 
 class PGGeneralIntegrator(PFGeneralIntegrator):
     """ 


### PR DESCRIPTION
Wraps the import of pygix in `PGGeneralIntegrator` with a try/except to address version mismatch issues.  See #184 