### PR TITLE
Relax version pin for numexpr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "silx==2.0.0",
     "pygix",
     "pydata_sphinx_theme",
-    "numexpr<2.8.5",
+    "numexpr!=2.8.5,!=2.8.6"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,4 @@ pillow
 xarray
 tqdm
 pydata_sphinx_theme
-# the following pin is due to a security update to numexpr: https://github.com/pydata/numexpr/issues/442
-# consider removing once this is resolved
-numexpr<2.8.5
+numexpr!=2.8.5,!=2.8.6


### PR DESCRIPTION
#157

Chore to change the overly restrictive numexpr pin to just knock out two known-bad releases.