### PR TITLE
`SST1RSoXSDB` fix dimension hinting for count plans

### DIFF
--- a/src/PyHyperScattering/SST1RSoXSDB.py
+++ b/src/PyHyperScattering/SST1RSoXSDB.py
@@ -625,7 +625,7 @@ class SST1RSoXSDB:
             elif "spiralsearch" in md["start"]["plan_name"] and dims is None:
                 dims = ["sam_x", "sam_y"]
             elif "count" in md["start"]["plan_name"] and dims is None:
-                dims = ["epoch"]
+                dims = ["time"]
             else:
                 axes_to_include = []
                 rsd_cutoff = 0.005

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -90,14 +90,12 @@ def test_SST1DB_load_energy_scan_20241209(sstdb):
     run = sstdb.loadRun(91175).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
-    assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_load_energy_scan_20250213(sstdb):
     run = sstdb.loadRun(92202).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
-    assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_load_spiral_scan_20250221(sstdb):
@@ -118,7 +116,6 @@ def test_SST1DB_load_energy_scan_20250223(sstdb):
     run = sstdb.loadRun(93065).unstack('system')
     assert type(run) == xr.DataArray
     assert 'energy' in run.indexes
-    assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_exposurewarnings(sstdb):

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -109,7 +109,6 @@ def test_SST1DB_load_count_scan_20250222(sstdb):
     run = sstdb.loadRun(92849).unstack('system')
     assert type(run) == xr.DataArray
     assert 'time' in run.indexes
-    assert 'polarization' in run.indexes
 
 @must_have_tiled
 def test_SST1DB_load_energy_scan_20250223(sstdb):

--- a/tests/test_SST1DBLoader.py
+++ b/tests/test_SST1DBLoader.py
@@ -108,7 +108,7 @@ def test_SST1DB_load_spiral_scan_20250221(sstdb):
 
 @must_have_tiled
 def test_SST1DB_load_count_scan_20250222(sstdb):
-    run = sstdb.loadRun(92849,dims=['time','polarization']).unstack('system')
+    run = sstdb.loadRun(92849).unstack('system')
     assert type(run) == xr.DataArray
     assert 'time' in run.indexes
     assert 'polarization' in run.indexes


### PR DESCRIPTION
`count` plans were originally limited to essentially single-frame snapshots where `epoch` was the appropriate dimension, but the per-image `time` is more appropriate if doing a multi-frame count at a single energy.  This short PR changes the dimension hinting code and updates the associated test to use the dimension hinting code.