### PR TITLE
Add concurrency limit on publish-docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -2,6 +2,9 @@ name: "Publish Documentation to NIST Pages"
 
 on: [push, pull_request, delete]
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #204 by adding a concurrency limit to the docs workflow forcing one-at-a-time execution.