### PR TITLE
Update pyproject.toml to add version specification for pyFAI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "h5py",
     "numpy",
     "pandas",
-    "pyfai",
+    "pyfai<=2024.9.0",
     "scikit-image",
     "scipy",
     "pillow",


### PR DESCRIPTION
Starting at pyFAI version 2024.10, the pyFAI azimuthal integrator module changed syntax which therefore messed up the rest of PHS. (Warning given: Module pyFAI.azimuthalIntegrator is deprecated since pyFAI version 2024.10. Use 'pyFAI.integrator.azimuthal' instead.)